### PR TITLE
[1.08] Change logs to log admin's name and guid

### DIFF
--- a/JM/COT/scripts/4_World/CommunityOnlineTools/CommunityOnlineToolsBase.c
+++ b/JM/COT/scripts/4_World/CommunityOnlineTools/CommunityOnlineToolsBase.c
@@ -175,7 +175,7 @@ class CommunityOnlineToolsBase
 	{
 		if ( GetGame().IsMultiplayer() )
 		{
-			text = "" + logInstacPlyer.GetSteam64ID() + ": " + text;
+			text = "" + logInstacPlyer.GetName() + " (" + logInstacPlyer.GetGUID() + "): " + text;
 		} else
 		{
 			text = "Offline: " + text;
@@ -198,7 +198,7 @@ class CommunityOnlineToolsBase
 	{
 		if ( GetGame().IsMultiplayer() )
 		{
-			text = "" + logIdentPlyer.GetPlainId() + ": " + text;
+			text = "" + logIdentPlyer.GetName() + " (" + logIdentPlyer.GetId() + "): " + text;
 		} else
 		{
 			text = "Offline: " + text;


### PR DESCRIPTION
Files are now using guids, so it makes more sense to log this instead of steam64. Logging admin's name makes it also way more redable imho.