### PR TITLE
Save character to hive and handle body when kicking

### DIFF
--- a/JM/COT/Scripts/5_Mission/CommunityOnlineTools/modules/Player/JMPlayerModule.c
+++ b/JM/COT/Scripts/5_Mission/CommunityOnlineTools/modules/Player/JMPlayerModule.c
@@ -1797,7 +1797,15 @@ Print("JMPlayerModule::RPC_EndSpectating_Finish - timestamp " + GetGame().GetTic
 			if ( player == NULL )
 				continue;
 
+			if (GetHive())
+			{
+				player.Save();
+				GetHive().CharacterExit(player);        
+			}
+
+			player.ReleaseNetworkControls();
 			GetGame().DisconnectPlayer(player.GetIdentity(), player.GetIdentity().GetId());
+			if (player) player.Delete();
 
 			GetCommunityOnlineToolsBase().Log( ident, "Kicked [guid=" + players[i].GetGUID() + "]" );
 


### PR DESCRIPTION
When kicking the character would stay in game, allowing the kicked player to rejoin essentially duping the character.